### PR TITLE
Implement scene management actions

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -5,6 +5,8 @@
 #include <QVBoxLayout>
 #include <QShortcut>
 #include <QKeySequence>
+#include <QMessageBox>
+#include <QFileInfo>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent),
@@ -19,8 +21,23 @@ MainWindow::MainWindow(QWidget *parent)
     viewer = new ImageViewer(ui->MainFrame);
     layout->addWidget(viewer);
 
+    locatorMode = false;
+    sceneFilePath.clear();
+
+
+    connect(ui->MainTree, &QTreeWidget::currentItemChanged,
+            this, &MainWindow::onTreeSelectionChanged);
+
     connect(ui->actionLoad, &QAction::triggered, this, &MainWindow::importImages);
+    connect(ui->actionNEW, &QAction::triggered, this, &MainWindow::newScene);
+    connect(ui->actionOpen, &QAction::triggered, this, &MainWindow::loadSceneTriggered);
+    connect(ui->actionSave, &QAction::triggered, this, &MainWindow::saveSceneTriggered);
+    connect(ui->actionSave_As, &QAction::triggered, this, &MainWindow::saveSceneAsTriggered);
     connect(ui->btnAddLoc, &QPushButton::clicked, this, &MainWindow::addLocator);
+    connect(ui->btnCalibrate, &QPushButton::clicked, this, &MainWindow::calibrate);
+    connect(ui->btnDFWS, &QPushButton::clicked, this, &MainWindow::defineWorldspace);
+    connect(ui->btnDFMM, &QPushButton::clicked, this, &MainWindow::defineReferenceDistance);
+    connect(ui->btnLocMod, &QPushButton::clicked, this, &MainWindow::addModelingLocator);
 
     connect(viewer, &ImageViewer::locatorAdded, this, &MainWindow::onLocatorAdded);
     connect(viewer, &ImageViewer::navigate, this, [this](int step){
@@ -29,6 +46,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     new QShortcut(QKeySequence(Qt::Key_Right), this, SLOT(nextImage()));
     new QShortcut(QKeySequence(Qt::Key_Left), this, SLOT(prevImage()));
+    QShortcut *delShort = new QShortcut(QKeySequence(Qt::Key_Delete), ui->MainTree);
+    connect(delShort, &QShortcut::activated, this, &MainWindow::deleteSelectedLocator);
+    QShortcut *escShort = new QShortcut(QKeySequence(Qt::Key_Escape), viewer);
+    connect(escShort, &QShortcut::activated, this, &MainWindow::exitLocatorMode);
 }
 
 MainWindow::~MainWindow()
@@ -46,7 +67,10 @@ void MainWindow::importImages()
     selectedLocator.clear();
     if (!images.isEmpty()) {
         showImage(0);
+    } else {
+        viewer->loadImage(QImage());
     }
+    updateTree();
 }
 
 QString MainWindow::getNextLocatorName() const
@@ -68,6 +92,7 @@ void MainWindow::addLocator()
     loc.name = selectedLocator;
     locators.append(loc);
     viewer->setAddingLocator(true);
+    updateTree();
 }
 
 void MainWindow::onLocatorAdded(float x, float y)
@@ -90,6 +115,7 @@ void MainWindow::onLocatorAdded(float x, float y)
         }
     }
     viewer->setMarkers(markers);
+    updateTree();
 }
 
 void MainWindow::showImage(int index, bool keepView)
@@ -122,6 +148,144 @@ void MainWindow::prevImage()
     if (images.isEmpty()) return;
     int idx = (currentIndex - 1 + images.size()) % images.size();
     showImage(idx, true);
+}
+
+void MainWindow::newScene()
+{
+    exitLocatorMode();
+    imagePaths.clear();
+    images.clear();
+    locators.clear();
+    selectedLocator.clear();
+    sceneFilePath.clear();
+    currentIndex = -1;
+    viewer->loadImage(QImage());
+    viewer->setMarkers({});
+    updateTree();
+}
+
+void MainWindow::saveSceneTriggered()
+{
+    if (sceneFilePath.isEmpty()) {
+        saveSceneAsTriggered();
+        return;
+    }
+    if (!saveScene(sceneFilePath, imagePaths, locators)) {
+        QMessageBox::critical(this, tr("Save Failed"), tr("Could not save scene."));
+    }
+}
+
+void MainWindow::saveSceneAsTriggered()
+{
+    QString path = QFileDialog::getSaveFileName(this, tr("Save Scene As"), sceneFilePath, tr("AMS Scene (*.ams)"));
+    if (path.isEmpty())
+        return;
+    if (!path.toLower().endsWith(".ams"))
+        path += ".ams";
+    sceneFilePath = path;
+    saveSceneTriggered();
+}
+
+void MainWindow::loadSceneTriggered()
+{
+    QString path = QFileDialog::getOpenFileName(this, tr("Load Scene"), QString(), tr("AMS Scene (*.ams)"));
+    if (path.isEmpty())
+        return;
+    QStringList imgs;
+    QList<LocatorData> locs;
+    if (!loadSceneAms(path, imgs, locs)) {
+        QMessageBox::critical(this, tr("Load Failed"), tr("Could not load scene."));
+        return;
+    }
+    sceneFilePath = path;
+    imagePaths = imgs;
+    images = loadImages(imgs);
+    locators = locs;
+    selectedLocator.clear();
+    if (!images.isEmpty())
+        showImage(0);
+    updateTree();
+}
+
+void MainWindow::calibrate()
+{
+    QMessageBox::information(this, tr("Calibrate"), tr("Calibration not implemented."));
+}
+
+void MainWindow::defineWorldspace()
+{
+    QMessageBox::information(this, tr("Worldspace"), tr("Define worldspace not implemented."));
+}
+
+void MainWindow::defineReferenceDistance()
+{
+    QMessageBox::information(this, tr("Reference Distance"), tr("Define reference distance not implemented."));
+}
+
+void MainWindow::addModelingLocator()
+{
+    QMessageBox::information(this, tr("Modeling Locator"), tr("Add modeling locator not implemented."));
+}
+
+void MainWindow::updateTree()
+{
+    ui->MainTree->clear();
+    QTreeWidgetItem *imgRoot = new QTreeWidgetItem(ui->MainTree, QStringList(tr("Images")));
+    for (int i = 0; i < imagePaths.size(); ++i) {
+        new QTreeWidgetItem(imgRoot, QStringList(QFileInfo(imagePaths[i]).fileName()));
+    }
+    QTreeWidgetItem *locRoot = new QTreeWidgetItem(ui->MainTree, QStringList(tr("Locators")));
+    for (const LocatorData &l : locators) {
+        new QTreeWidgetItem(locRoot, QStringList(l.name));
+    }
+    imgRoot->setExpanded(true);
+    locRoot->setExpanded(true);
+}
+
+void MainWindow::exitLocatorMode()
+{
+    locatorMode = false;
+    viewer->setAddingLocator(false);
+}
+
+void MainWindow::onTreeSelectionChanged(QTreeWidgetItem *current, QTreeWidgetItem *)
+{
+    if (!current)
+        return;
+    QTreeWidgetItem *parent = current->parent();
+    if (!parent)
+        return;
+    QString pText = parent->text(0);
+    if (pText == tr("Images")) {
+        exitLocatorMode();
+        int idx = parent->indexOfChild(current);
+        showImage(idx);
+    } else if (pText == tr("Locators")) {
+        selectedLocator = current->text(0);
+        locatorMode = true;
+        viewer->setAddingLocator(true);
+    }
+}
+
+void MainWindow::deleteSelectedLocator()
+{
+    QTreeWidgetItem *item = ui->MainTree->currentItem();
+    if (!item || !item->parent())
+        return;
+    if (item->parent()->text(0) != tr("Locators"))
+        return;
+    QString name = item->text(0);
+    for (int i = 0; i < locators.size(); ++i) {
+        if (locators[i].name == name) {
+            locators.removeAt(i);
+            break;
+        }
+    }
+    if (selectedLocator == name)
+        selectedLocator.clear();
+    updateTree();
+    if (currentIndex >= 0)
+        showImage(currentIndex, true);
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include "imageviewer.h"
 #include "amutilities.h"
+#include <QTreeWidgetItem>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -22,13 +23,25 @@ public:
 private slots:
     void importImages();
     void addLocator();
+    void newScene();
+    void saveSceneTriggered();
+    void saveSceneAsTriggered();
+    void loadSceneTriggered();
+    void calibrate();
+    void defineWorldspace();
+    void defineReferenceDistance();
+    void addModelingLocator();
     void nextImage();
     void prevImage();
     void onLocatorAdded(float x, float y);
+    void onTreeSelectionChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
+    void deleteSelectedLocator();
+    void exitLocatorMode();
 
 private:
     void showImage(int index, bool keepView = false);
     QString getNextLocatorName() const;
+    void updateTree();
 
     Ui::MainWindow *ui;
     ImageViewer *viewer;
@@ -36,6 +49,8 @@ private:
     QVector<QImage> images;
     QList<LocatorData> locators;
     QString selectedLocator;
+    QString sceneFilePath;
+    bool locatorMode;
     int currentIndex;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- integrate menu actions for new/open/save scene
- add placeholder functions for calibration and other tools
- implement QTreeWidget view of images and locators
- enable deleting locators and toggling locator mode

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_686810e06804832eb99a01e0ef517f96