### PR TITLE
Add calibration integration

### DIFF
--- a/camera_calibrator.h
+++ b/camera_calibrator.h
@@ -17,6 +17,7 @@ public:
   QVector<QMatrix3x3> getIntrinsics() const { return m_intrinsics; }
   QVector<QMatrix3x3> getRotations() const { return m_rotations; }
   QVector<QVector3D> getTranslations() const { return m_translations; }
+  QVector<int> getRegisteredIndices() const { return m_registeredIndices; }
   QMap<int, double> getReprojectionErrorPerImage() const;
 
 private:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -11,6 +11,11 @@
 #include "tools.h"
 #include <event.h>
 #include <QMimeData>
+#include <optional>
+#include <limits>
+#include <cmath>
+#include <Eigen/Core>
+#include <Eigen/SVD>
 
 
 MainWindow::MainWindow(QWidget *parent)
@@ -57,7 +62,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->actionSave, &QAction::triggered, this, &MainWindow::saveSceneTriggered);
     connect(ui->actionSave_As, &QAction::triggered, this, &MainWindow::saveSceneAsTriggered);
     connect(ui->btnAddLoc, &QPushButton::clicked, this, &MainWindow::addLocator);
-    //connect(ui->btnCalibrate, &QPushButton::clicked, this, &MainWindow::calibrate);
+    connect(ui->btnCalibrate, &QPushButton::clicked, this, &MainWindow::calibrate);
     connect(ui->btnDFWS, &QPushButton::clicked, this, &MainWindow::defineWorldspace);
     connect(ui->btnDFMM, &QPushButton::clicked, this, &MainWindow::defineReferenceDistance);
     connect(ui->btnLocMod, &QPushButton::clicked, this, &MainWindow::addModelingLocator);
@@ -229,6 +234,130 @@ void MainWindow::loadSceneTriggered(QString filename)
     if (!images.isEmpty())
         showImage(0);
     updateTree();
+}
+
+void MainWindow::calibrate()
+{
+    if (imagePaths.isEmpty()) {
+        QMessageBox::warning(this, tr("Calibrate"),
+                             tr("No images loaded for calibration."));
+        return;
+    }
+
+    CameraCalibrator calibrator;
+    calibrator.loadImages(imagePaths);
+
+    QMap<int, QMap<int, QPointF>> pointData;
+    for (int setId = 0; setId < locators.size(); ++setId) {
+        QMap<int, QPointF> map;
+        for (auto it = locators[setId].positions.begin();
+             it != locators[setId].positions.end(); ++it) {
+            int idx = it.key();
+            if (idx < 0 || idx >= images.size())
+                continue;
+            QPointF p = it.value();
+            QPointF pix(p.x() * images[idx].width(),
+                        p.y() * images[idx].height());
+            map.insert(idx, pix);
+        }
+        if (!map.isEmpty())
+            pointData.insert(setId, map);
+    }
+
+    calibrator.loadPointData(pointData);
+    if (!calibrator.calibrate()) {
+        QMessageBox::critical(this, tr("Calibrate"),
+                              tr("Calibration failed. Check your points."));
+        return;
+    }
+
+    imageErrors = calibrator.getReprojectionErrorPerImage();
+
+    // Compute per-locator errors
+    QMap<int, Eigen::Matrix<double, 3, 4>> Pmats;
+    QVector<int> regIdx = calibrator.getRegisteredIndices();
+    auto intr = calibrator.getIntrinsics();
+    auto rot = calibrator.getRotations();
+    auto trans = calibrator.getTranslations();
+    for (int idx : regIdx) {
+        if (idx >= intr.size() || idx >= rot.size() || idx >= trans.size())
+            continue;
+        Eigen::Matrix3d K, Rwc;
+        for (int r = 0; r < 3; ++r) {
+            for (int c = 0; c < 3; ++c) {
+                K(r, c) = intr[idx](r, c);
+                Rwc(r, c) = rot[idx](r, c);
+            }
+        }
+        Eigen::Vector3d twc(trans[idx].x(), trans[idx].y(), trans[idx].z());
+        Eigen::Matrix3d Rcw = Rwc.transpose();
+        Eigen::Vector3d tcw = -Rcw * twc;
+        Eigen::Matrix<double, 3, 4> P;
+        P.leftCols<3>() = Rcw;
+        P.col(3) = tcw;
+        P = K * P;
+        Pmats[idx] = P;
+    }
+
+    auto triangulatePointFn = [](const QMap<int, QPointF> &obs,
+                                 const QMap<int, Eigen::Matrix<double, 3, 4>> &P) {
+        std::vector<Eigen::Vector4d> rows;
+        for (auto it = obs.begin(); it != obs.end(); ++it) {
+            int i = it.key();
+            if (!P.contains(i))
+                continue;
+            const auto &mat = P[i];
+            double x = it.value().x();
+            double y = it.value().y();
+            rows.emplace_back(x * mat.row(2) - mat.row(0));
+            rows.emplace_back(y * mat.row(2) - mat.row(1));
+        }
+        if (rows.size() < 4)
+            return std::optional<Eigen::Vector3d>();
+        Eigen::MatrixXd A(rows.size(), 4);
+        for (int i = 0; i < rows.size(); ++i)
+            A.row(i) = rows[i];
+        Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullV);
+        Eigen::Vector4d X = svd.matrixV().col(3);
+        X /= X(3);
+        return std::optional<Eigen::Vector3d>(X.head<3>());
+    };
+
+    for (int setId : pointData.keys()) {
+        const auto &obs = pointData[setId];
+        auto optX = triangulatePointFn(obs, Pmats);
+        if (!optX) {
+            locators[setId].error = std::numeric_limits<float>::infinity();
+            continue;
+        }
+        Eigen::Vector4d Xh;
+        Xh << *optX, 1.0;
+        double total = 0.0;
+        int count = 0;
+        for (auto it = obs.begin(); it != obs.end(); ++it) {
+            int i = it.key();
+            if (!Pmats.contains(i))
+                continue;
+            const auto &P = Pmats[i];
+            Eigen::Vector3d proj = P * Xh;
+            proj /= proj(2);
+            QPointF pt = it.value();
+            double err = std::hypot(pt.x() - proj(0), pt.y() - proj(1));
+            total += err;
+            count += 1;
+        }
+        if (count)
+            locators[setId].error = static_cast<float>(total / count);
+        else
+            locators[setId].error = std::numeric_limits<float>::infinity();
+    }
+
+    updateTree();
+    if (currentIndex >= 0)
+        showImage(currentIndex, true);
+
+    QMessageBox::information(this, tr("Calibration Completed"),
+                             tr("Calibration finished successfully."));
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -5,6 +5,7 @@
 #include "imageviewer.h"
 #include "tools.h"
 #include "amutilities.h"
+#include "camera_calibrator.h"
 #include <QTreeWidgetItem>
 
 QT_BEGIN_NAMESPACE
@@ -31,7 +32,7 @@ private slots:
     void saveSceneTriggered();
     void saveSceneAsTriggered();
     void loadSceneTriggered(QString filename);
-//void calibrate();
+    void calibrate();
     void defineWorldspace();
     void defineReferenceDistance();
     void addModelingLocator();


### PR DESCRIPTION
## Summary
- hook up calibration button in the Qt interface
- implement `calibrate()` slot that passes scene images and locator data to `CameraCalibrator`
- compute and display reprojection errors per image and locator
- expose registered image indices from `CameraCalibrator`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_686abe502124832eb43da1422e5f067e